### PR TITLE
Ensure metric names are strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.1.1
+
+* Automatically convert metric and instrumentation block names to Strings, since i.e.
+  Appsignal cannot deal with Symbol names for those.
+
+# 1.1.0
+
+* Ensure #increment_counter provides the default increment of 1 to the drivers
+
 # 1.0.0
 
-Initial release
+* Initial release

--- a/lib/measurometer.rb
+++ b/lib/measurometer.rb
@@ -50,7 +50,7 @@ module Measurometer
       blk_with_capture = -> { blk_return_value = blk.call }
       @drivers.inject(blk_with_capture) { |outer_block, driver|
         -> {
-          driver.instrument(block_name, &outer_block)
+          driver.instrument(block_name.to_s, &outer_block)
         }
       }.call
       blk_return_value
@@ -62,7 +62,7 @@ module Measurometer
     # @param value[Numeric] distribution value
     # @return nil
     def add_distribution_value(value_path, value)
-      @drivers.each { |d| d.add_distribution_value(value_path, value) }
+      @drivers.each { |d| d.add_distribution_value(value_path.to_s, value) }
       nil
     end
 
@@ -72,7 +72,7 @@ module Measurometer
     # @param by[Integer] the counter increment to apply
     # @return nil
     def increment_counter(counter_path, by = 1)
-      @drivers.each { |d| d.increment_counter(counter_path, by) }
+      @drivers.each { |d| d.increment_counter(counter_path.to_s, by) }
       nil
     end
 
@@ -82,7 +82,7 @@ module Measurometer
     # @param value[Integer] the absolute value of the gauge
     # @return nil
     def set_gauge(gauge_name, value)
-      @drivers.each { |d| d.set_gauge(gauge_name, value) }
+      @drivers.each { |d| d.set_gauge(gauge_name.to_s, value) }
       nil
     end
   end

--- a/lib/measurometer/version.rb
+++ b/lib/measurometer/version.rb
@@ -1,3 +1,3 @@
 module Measurometer
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/measurometer/statsd_driver_spec.rb
+++ b/spec/measurometer/statsd_driver_spec.rb
@@ -17,7 +17,7 @@ describe 'Measurometer::StatsdDriver' do
     Measurometer.increment_counter('app.some_counter', 2)
     Measurometer.add_distribution_value('app.some_sample', 42)
 
-    expect(statsd).to have_received(:timing) {|block_name, timing_millis|
+    expect(statsd).to have_received(:timing) { |block_name, timing_millis|
       expect(block_name).to eq('some_block.x')
       expect(timing_millis).to be_within(20).of(200)
     }

--- a/spec/measurometer_spec.rb
+++ b/spec/measurometer_spec.rb
@@ -35,6 +35,52 @@ RSpec.describe Measurometer do
     end
   end
 
+  describe '.add_distribution_value' do
+    it 'converts the metric name to a String before passing it to the driver' do
+      driver = double
+      expect(driver).to receive(:add_distribution_value).with('bar_intensity', 114.4)
+
+      Measurometer.drivers << driver
+      result = Measurometer.add_distribution_value(:bar_intensity, 114.4)
+      expect(result).to be_nil
+      Measurometer.drivers.delete(driver)
+    end
+  end
+
+  describe '.increment_counter' do
+    it 'increments by 1 by default and converts the counter name to a String before passing it to the driver' do
+      driver = double
+      expect(driver).to receive(:increment_counter).with('barness', 1)
+
+      Measurometer.drivers << driver
+      result = Measurometer.increment_counter(:barness)
+      expect(result).to be_nil
+      Measurometer.drivers.delete(driver)
+    end
+
+    it 'passes the increment to the driver' do
+      driver = double
+      expect(driver).to receive(:increment_counter).with('barness', 123)
+
+      Measurometer.drivers << driver
+      result = Measurometer.increment_counter(:barness, 123)
+      expect(result).to be_nil
+      Measurometer.drivers.delete(driver)
+    end
+  end
+
+  describe '.set_gauge' do
+    it 'converts the gauge name to a String before passing it to the driver' do
+      driver = double
+      expect(driver).to receive(:set_gauge).with('fooeyness', 456)
+
+      Measurometer.drivers << driver
+      result = Measurometer.set_gauge(:fooeyness, 456)
+      expect(result).to be_nil
+      Measurometer.drivers.delete(driver)
+    end
+  end
+
   describe '.instrument' do
     it 'preserves the return value of the block even if one of the drivers swallows it' do
       bad_driver = Object.new
@@ -48,6 +94,22 @@ RSpec.describe Measurometer do
         :block_result
       end
       Measurometer.drivers.delete(bad_driver)
+
+      expect(instrument_result).to eq(:block_result)
+    end
+
+    it 'converts the block name to a String before passing it to the instrumenters' do
+      instrumentation_driver = Object.new
+      def instrumentation_driver.instrument(block_name)
+        raise 'Block name must be a string' unless block_name.is_a?(String)
+        yield
+      end
+
+      Measurometer.drivers << instrumentation_driver
+      instrument_result = Measurometer.instrument(:foo) do
+        :block_result
+      end
+      Measurometer.drivers.delete(instrumentation_driver)
 
       expect(instrument_result).to eq(:block_result)
     end


### PR DESCRIPTION
Appsignal refuses to accept a Symbol as the name for the
instrumented block, and we might as well convert into a String
when we set metrics.

This will have a tiny performance impact but it seems
an acceptable in the long run. Alternatively we could add
a wrapper for Appsignal specifically which would have to
perform the same conversion, as well as for any other drivers
which do not want anything but Strings.