### PR TITLE
Support appsignal tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on: [push,pull_request]
+
+env:
+  BUNDLE_PATH: vendor/bundle
+
+jobs:
+  test:
+    name: Specs
+    runs-on: ubuntu-18.04
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      matrix:
+        ruby:
+          - 2.7
+          - 2.6
+          - 2.5
+        experimental: [false]
+        include:
+          - ruby: 3.0
+            experimental: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Gemfile Cache
+        uses: actions/cache@v2
+        with:
+          path: Gemfile.lock
+          key: ${{ runner.os }}-gemlock-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'measurometer.gemspec') }}
+          restore-keys: |
+            ${{ runner.os }}-gemlock-${{ matrix.ruby }}-
+      - name: Bundle Cache
+        id: cache-gems
+        uses: actions/cache@v2
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gems-${{ matrix.ruby }}-${{ hashFiles('Gemfile', 'Gemfile.lock', 'measurometer.gemspec') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-${{ matrix.ruby }}-
+            ${{ runner.os }}-gems-
+      - name: Bundle Install
+        if: steps.cache-gems.outputs.cache-hit != 'true'
+        run: bundle install --jobs 4 --retry 3
+      - name: RSpec
+        continue-on-error: ${{ matrix.experimental }}
+        run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # rspec failure tracking
 .rspec_status
+
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-sudo: false
-language: ruby
-rvm:
-  - 2.3.3
-before_install: gem install bundler -v 1.14.6

--- a/lib/measurometer.rb
+++ b/lib/measurometer.rb
@@ -71,8 +71,8 @@ module Measurometer
     # @param counter_path[String] under which path to push the metric
     # @param by[Integer] the counter increment to apply
     # @return nil
-    def increment_counter(counter_path, by = 1)
-      @drivers.each { |d| d.increment_counter(counter_path.to_s, by) }
+    def increment_counter(counter_path, by = 1, **tags)
+      @drivers.each { |d| d.increment_counter(counter_path.to_s, by, **tags) }
       nil
     end
 
@@ -81,8 +81,8 @@ module Measurometer
     # @param gauge_name[String] under which path to push the metric
     # @param value[Integer] the absolute value of the gauge
     # @return nil
-    def set_gauge(gauge_name, value)
-      @drivers.each { |d| d.set_gauge(gauge_name.to_s, value) }
+    def set_gauge(gauge_name, value, **tags)
+      @drivers.each { |d| d.set_gauge(gauge_name.to_s, value, **tags) }
       nil
     end
   end

--- a/lib/measurometer.rb
+++ b/lib/measurometer.rb
@@ -71,8 +71,8 @@ module Measurometer
     # @param counter_path[String] under which path to push the metric
     # @param by[Integer] the counter increment to apply
     # @return nil
-    def increment_counter(counter_path, by = 1, **tags)
-      @drivers.each { |d| d.increment_counter(counter_path.to_s, by, **tags) }
+    def increment_counter(counter_path, by = 1, tags={})
+      @drivers.each { |d| d.increment_counter(counter_path.to_s, by, tags) }
       nil
     end
 
@@ -81,8 +81,8 @@ module Measurometer
     # @param gauge_name[String] under which path to push the metric
     # @param value[Integer] the absolute value of the gauge
     # @return nil
-    def set_gauge(gauge_name, value, **tags)
-      @drivers.each { |d| d.set_gauge(gauge_name.to_s, value, **tags) }
+    def set_gauge(gauge_name, value, tags={})
+      @drivers.each { |d| d.set_gauge(gauge_name.to_s, value, tags) }
       nil
     end
   end

--- a/lib/measurometer/statsd_driver.rb
+++ b/lib/measurometer/statsd_driver.rb
@@ -17,7 +17,7 @@ module Measurometer
       end
     end
 
-    def increment_counter(counter_name, by)
+    def increment_counter(counter_name, by, **_tags)
       @statsd_client.increment(counter_name, by)
     end
 
@@ -25,7 +25,7 @@ module Measurometer
       @statsd_client.count(key_path, value)
     end
 
-    def set_gauge(gauge_name, value)
+    def set_gauge(gauge_name, value, **_tags)
       @statsd_client.gauge(gauge_name, value)
     end
 

--- a/lib/measurometer/statsd_driver.rb
+++ b/lib/measurometer/statsd_driver.rb
@@ -17,7 +17,7 @@ module Measurometer
       end
     end
 
-    def increment_counter(counter_name, by, **_tags)
+    def increment_counter(counter_name, by, _tags={})
       @statsd_client.increment(counter_name, by)
     end
 
@@ -25,7 +25,7 @@ module Measurometer
       @statsd_client.count(key_path, value)
     end
 
-    def set_gauge(gauge_name, value, **_tags)
+    def set_gauge(gauge_name, value, _tags={})
       @statsd_client.gauge(gauge_name, value)
     end
 

--- a/measurometer.gemspec
+++ b/measurometer.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |spec|
   spec.version       = Measurometer::VERSION
   spec.authors       = ['Julik Tarkhanov']
   spec.email         = ['me@julik.nl']
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.5.0")
 
   spec.summary       = 'Minimum viable API for instrumentation in libraries'
   spec.description   = 'Minimum viable API for instrumentation in libraries. Source metrics from your libraries to Measurometer, pick them up on the other end in the application, centrally.'

--- a/spec/measurometer/statsd_driver_spec.rb
+++ b/spec/measurometer/statsd_driver_spec.rb
@@ -14,7 +14,9 @@ describe 'Measurometer::StatsdDriver' do
     end
 
     Measurometer.set_gauge('app.some_gauge', 42)
+    Measurometer.set_gauge('app.another_gauge', 43, ignore_this_tag: 2)
     Measurometer.increment_counter('app.some_counter', 2)
+    Measurometer.increment_counter('app.another_counter', 3, ignore_this_tag: 1)
     Measurometer.add_distribution_value('app.some_sample', 42)
 
     expect(statsd).to have_received(:timing) { |block_name, timing_millis|
@@ -23,6 +25,8 @@ describe 'Measurometer::StatsdDriver' do
     }
 
     expect(statsd).to have_received(:increment).with('app.some_counter', 2)
+    expect(statsd).to have_received(:increment).with('app.another_counter', 3)
     expect(statsd).to have_received(:count).with('app.some_sample', 42)
+    expect(statsd).to have_received(:gauge).with('app.another_gauge', 43)
   end
 end

--- a/spec/measurometer_spec.rb
+++ b/spec/measurometer_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Measurometer do
   describe '.increment_counter' do
     it 'increments by 1 by default and converts the counter name to a String before passing it to the driver' do
       driver = double
-      expect(driver).to receive(:increment_counter).with('barness', 1)
+      expect(driver).to receive(:increment_counter).with('barness', 1, {})
 
       Measurometer.drivers << driver
       result = Measurometer.increment_counter(:barness)
@@ -59,7 +59,7 @@ RSpec.describe Measurometer do
 
     it 'passes the increment to the driver' do
       driver = double
-      expect(driver).to receive(:increment_counter).with('barness', 123)
+      expect(driver).to receive(:increment_counter).with('barness', 123, {})
 
       Measurometer.drivers << driver
       result = Measurometer.increment_counter(:barness, 123)
@@ -79,7 +79,7 @@ RSpec.describe Measurometer do
   describe '.set_gauge' do
     it 'converts the gauge name to a String before passing it to the driver' do
       driver = double
-      expect(driver).to receive(:set_gauge).with('fooeyness', 456)
+      expect(driver).to receive(:set_gauge).with('fooeyness', 456, {})
 
       Measurometer.drivers << driver
       result = Measurometer.set_gauge(:fooeyness, 456)
@@ -147,12 +147,12 @@ RSpec.describe Measurometer do
         @distributions << [value_path, value]
       end
 
-      def increment_counter(value_path, value)
+      def increment_counter(value_path, value, tags={})
         @counters ||= []
         @counters << [value_path, value]
       end
 
-      def set_gauge(value_path, value)
+      def set_gauge(value_path, value, tags={})
         @gauges ||= []
         @gauges << [value_path, value]
       end

--- a/spec/measurometer_spec.rb
+++ b/spec/measurometer_spec.rb
@@ -67,6 +67,16 @@ RSpec.describe Measurometer do
       expect(result).to be_nil
       Measurometer.drivers.delete(driver)
     end
+
+    it 'passes tags to the driver' do
+      driver = double
+      expect(driver).to receive(:increment_counter).with('barness', 123, tag1: 11, tag2: 22)
+
+      Measurometer.drivers << driver
+      result = Measurometer.increment_counter(:barness, 123, tag1: 11, tag2: 22)
+      expect(result).to be_nil
+      Measurometer.drivers.delete(driver)
+    end
   end
 
   describe '.set_gauge' do
@@ -76,6 +86,16 @@ RSpec.describe Measurometer do
 
       Measurometer.drivers << driver
       result = Measurometer.set_gauge(:fooeyness, 456)
+      expect(result).to be_nil
+      Measurometer.drivers.delete(driver)
+    end
+
+    it 'passes tags to the driver' do
+      driver = double
+      expect(driver).to receive(:set_gauge).with('fooeyness', 123, tag1: 11, tag2: 22)
+
+      Measurometer.drivers << driver
+      result = Measurometer.set_gauge(:fooeyness, 123, tag1: 11, tag2: 22)
       expect(result).to be_nil
       Measurometer.drivers.delete(driver)
     end

--- a/spec/measurometer_spec.rb
+++ b/spec/measurometer_spec.rb
@@ -9,13 +9,14 @@ RSpec.describe Measurometer do
     end
   end
 
+  before(:each) { Measurometer.drivers.clear }
+  after(:each) { Measurometer.drivers.clear }
+
   it 'has a version number' do
     expect(Measurometer::VERSION).not_to be nil
   end
 
   describe '.drivers' do
-    before(:each) { Measurometer.drivers.clear }
-    after(:each) { Measurometer.drivers.clear }
     let(:driver) { Object.new }
 
     it 'allows adding and removing a driver' do
@@ -43,7 +44,6 @@ RSpec.describe Measurometer do
       Measurometer.drivers << driver
       result = Measurometer.add_distribution_value(:bar_intensity, 114.4)
       expect(result).to be_nil
-      Measurometer.drivers.delete(driver)
     end
   end
 
@@ -55,7 +55,6 @@ RSpec.describe Measurometer do
       Measurometer.drivers << driver
       result = Measurometer.increment_counter(:barness)
       expect(result).to be_nil
-      Measurometer.drivers.delete(driver)
     end
 
     it 'passes the increment to the driver' do
@@ -65,7 +64,6 @@ RSpec.describe Measurometer do
       Measurometer.drivers << driver
       result = Measurometer.increment_counter(:barness, 123)
       expect(result).to be_nil
-      Measurometer.drivers.delete(driver)
     end
 
     it 'passes tags to the driver' do
@@ -75,7 +73,6 @@ RSpec.describe Measurometer do
       Measurometer.drivers << driver
       result = Measurometer.increment_counter(:barness, 123, tag1: 11, tag2: 22)
       expect(result).to be_nil
-      Measurometer.drivers.delete(driver)
     end
   end
 
@@ -87,7 +84,6 @@ RSpec.describe Measurometer do
       Measurometer.drivers << driver
       result = Measurometer.set_gauge(:fooeyness, 456)
       expect(result).to be_nil
-      Measurometer.drivers.delete(driver)
     end
 
     it 'passes tags to the driver' do
@@ -97,7 +93,6 @@ RSpec.describe Measurometer do
       Measurometer.drivers << driver
       result = Measurometer.set_gauge(:fooeyness, 123, tag1: 11, tag2: 22)
       expect(result).to be_nil
-      Measurometer.drivers.delete(driver)
     end
   end
 


### PR DESCRIPTION
Currently it's not possible to set a tag on Appsignal using this gem.

This PR adds support for that.

It also:
- replaces Travis with Github actions
- improves `measurometer_spec` to clean the drivers after each IT