### PR TITLE
Add a warning about a breaking change in 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 * Adds support to set a tag on Appsignal in methods `increment_counter` and `set_gauge`
 
+**Warning**: this version introduced a breaking change. It will be necessary to
+add the new 3rd argument to the methods `#increment_counter` and `#set_gauge` if you
+have a custom driver defined in your application, for example:
+
+```diff
+-class CustomDriver
+-  def increment_counter(counter_name, by)
+-  def set_gauge(gauge_name, value)
++class CustomDriver
++  def increment_counter(counter_name, by, _tags={})
++  def set_gauge(gauge_name, value, _tags={})
+```
+
 # 1.1.1
 
 * Automatically convert metric and instrumentation block names to Strings, since i.e.


### PR DESCRIPTION
We noticed that the version 1.2.0 introduced a breaking change for applications that have custom drivers.

This PR adds a warning about it in the CHANGELOG.

I think there's no use to create a new version 2.0, which was my initial thought, because the version 1.2.0 will still exist in Rubygems.