### PR TITLE
Bug in statsd client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.3.2
+
+* Bug-fix: for statsd `by` is an option, not a function argument
+
 # 1.3.1
 
 * Adds support for tags on the `statsd_driver.rb`

--- a/lib/measurometer/statsd_driver.rb
+++ b/lib/measurometer/statsd_driver.rb
@@ -18,7 +18,7 @@ module Measurometer
     end
 
     def increment_counter(counter_name, by, tags = {})
-      @statsd_client.increment(counter_name, by, tags: convert_hash_tags(tags))
+      @statsd_client.increment(counter_name, by: by, tags: convert_hash_tags(tags))
     end
 
     def add_distribution_value(key_path, value, tags = {})

--- a/lib/measurometer/version.rb
+++ b/lib/measurometer/version.rb
@@ -1,3 +1,3 @@
 module Measurometer
-  VERSION = '1.3.1'
+  VERSION = '1.3.2'
 end

--- a/spec/measurometer/statsd_driver_spec.rb
+++ b/spec/measurometer/statsd_driver_spec.rb
@@ -24,8 +24,8 @@ describe 'Measurometer::StatsdDriver' do
       expect(timing_millis).to be_within(20).of(200)
     }
 
-    expect(statsd).to have_received(:increment).with('app.some_counter', 2, tags: [])
-    expect(statsd).to have_received(:increment).with('app.another_counter', 3, tags: ['example_tag:1'])
+    expect(statsd).to have_received(:increment).with('app.some_counter', by: 2, tags: [])
+    expect(statsd).to have_received(:increment).with('app.another_counter', by: 3, tags: ['example_tag:1'])
     expect(statsd).to have_received(:count).with('app.some_sample', 42, tags: [])
     expect(statsd).to have_received(:gauge).with('app.another_gauge', 43, tags: ['example_tag:2'])
   end


### PR DESCRIPTION
For `increment` statsd only takes 2 arguments, not three. Pass `by` in the correct fashion.